### PR TITLE
Fix overlap condition & segregate EE1 tier from other output

### DIFF
--- a/TotalTimeGrouped1.py
+++ b/TotalTimeGrouped1.py
@@ -96,9 +96,9 @@ for file_path in glob.glob('{}/*.eaf'.format(sys.argv[1])):
                             value_target_end = int(value2.split('-')[1])
                             value_target_begin = int(value2.split('-')[0])
                             
-                            if value_target_begin<value_original_end and value_target_begin > value_original_begin:
+                            if value_target_begin<value_original_end and value_target_begin >= value_original_begin:
                                 
-                                if value_target_end < value_original_end :
+                                if value_target_end <= value_original_end :
                                     
                                     intersection_dict[key2]+=value_target_end-value_target_begin
                                     
@@ -107,16 +107,16 @@ for file_path in glob.glob('{}/*.eaf'.format(sys.argv[1])):
                                     intersection_dict[key2]+=value_original_end - value_target_begin
                                     
                             #target's end is encompassed by the original's begin and end
-                            elif value_target_end>value_original_begin and value_target_end < value_original_end :
+                            elif value_target_end>value_original_begin and value_target_end <= value_original_end :
                                 #which one is larger? target's begin or original's
                                 #reverse logic as larger time needs to get subtracted
-                                if value_target_begin < value_original_begin :
+                                if value_target_begin <= value_original_begin :
                                     intersection_dict[key2]=intersection_dict[key2]+value_target_end-value_original_begin
                                     
                                 else:
                                     intersection_dict[key2]+=value_target_end-value_target_begin
                                 
-                            if value_original_begin>value_target_begin and value_original_end<value_target_end:
+                            if value_original_begin >= value_target_begin and value_original_end <= value_target_end:
                                 
                                 intersection_dict[key2]+=value_original_end-value_original_begin
                                 

--- a/TotalTimeGrouped1.py
+++ b/TotalTimeGrouped1.py
@@ -18,6 +18,9 @@ ignore_tier_names=['code_num','on_off', 'context', 'code']
 # Tiers to exclude from CDS, ADS, and BOTH totals:
 xds_exluded_tiers = ['EE1', 'CHI']
 
+# Tiers to report separate from other tiers:
+segregated_tiers = ['EE1']
+
 #if the output file exists, delete it!
 if os.path.isfile(sys.argv[2]):
     os.remove(sys.argv[2])
@@ -82,6 +85,14 @@ for file_path in glob.glob('{}/*.eaf'.format(sys.argv[1])):
             keylist2 = tier_dictionary.keys()
             keylist2.sort()
             for key2 in keylist2:
+                if key2 in segregated_tiers:
+                    if key2 == key:
+                        for value in tier_dictionary[key]:
+                            begin = int(value.split('-')[0])
+                            end   = int(value.split('-')[1])
+                            total_time += end - begin
+                    writingFile.write("0,")
+                    continue
                 intersection_dict[key2]=0
                 for value in tier_dictionary[key]:
                     
@@ -156,16 +167,17 @@ for file_path in glob.glob('{}/*.eaf'.format(sys.argv[1])):
                 both=0
             writingFile.write(str(ads) + "," + str(cds)+","+str(both)+",")
 
-            if key not in xds_exluded_tiers:
+            if key not in xds_exluded_tiers and key not in segregated_tiers:
                 ads_total+=ads
                 cds_total+=cds
                 both_total+=both
             
             
             total_time -=total_intersection
-            total_intersection_accross+=total_intersection
+            if key not in segregated_tiers:
+                total_intersection_accross += total_intersection
+                grand_total += total_time
             writingFile.write(str(total_intersection)+","+str(total_time)+"\n")
-            grand_total+=total_time
             print("total " + str(total_time))
         writingFile.write(",")    
         for tier_name in (tier_names_targets):

--- a/TotalTimeGrouped1.py
+++ b/TotalTimeGrouped1.py
@@ -15,6 +15,9 @@ warnings.filterwarnings("ignore")
 # tier_names = ['FA1', 'FA2','CHI']#code_num,on_off, context, code
 ignore_tier_names=['code_num','on_off', 'context', 'code']
 
+# Tiers to exclude from CDS, ADS, and BOTH totals:
+xds_exluded_tiers = ['EE1', 'CHI']
+
 #if the output file exists, delete it!
 if os.path.isfile(sys.argv[2]):
     os.remove(sys.argv[2])
@@ -152,9 +155,11 @@ for file_path in glob.glob('{}/*.eaf'.format(sys.argv[1])):
                 cds = 0
                 both=0
             writingFile.write(str(ads) + "," + str(cds)+","+str(both)+",")
-            ads_total+=ads
-            cds_total+=cds
-            both_total+=both
+
+            if key not in xds_exluded_tiers:
+                ads_total+=ads
+                cds_total+=cds
+                both_total+=both
             
             
             total_time -=total_intersection


### PR DESCRIPTION
This is a set of three different changes:

## Overlap detection fix

The conditionals for overlap detection were failing in cases where two annotation segments began or ended at the same time (shared the same timestamp) because the tests were all strictly `<` or `>`. I replaced the relevant ones (where we're comparing two `begin` timestamps or two `end` timestamps with each other) to use `<=` or `>=`. This catches a few overlaps that were previously being missed.

Note: overlap detection still isn't quite correct in all cases, because it doesn't handle the case where more than two annotation segments are overlapping at the same time. I have a more robust fix for that in mind, but it's a much more significant change to the code.

## Exclusion of `EE1` and `CHI` from ADS/CDS totals

@melsod requested that the `EE1` tier be excluded from totals due to inconsistencies across corpora in the data. Its values for ADS, CDS, and BOTH are now not included in the totals reported on the final line of output. `CHI` is also in the exclusion list for these, because its annotations should not have those codes in the first place. To update the list of tiers excluded in this fashion, change the value of `xds_excluded_tiers[]` accordingly.

## Segregation of `EE1` from totals and overlap

@melsod also requested that the `EE1` tier be excluded from the grand totals reported at the end of each `eaf` file. To do this correctly, we need to also segregate its overlap totals with other tiers. This tier's totals are still reported, but any overlap with other tiers only gets reported on the `EE1` row of the output, and those overlap values do not get subtracted from the grand total reported for the file (unlike the overlap values of the other tiers with each other).

## Summary

- The grand totals for each file is reported as if the `EE1` tier does not exist.
- The grand total for each file does include values for the `CHI` tier.
- The ADS, CDS, and BOTH totals for each file exclude any amounts from both the `EE1` and `CHI` tiers.
