### PR TITLE
Add a feature to use a tier to restrict processing to that tier's segments

### DIFF
--- a/summarize-eaf.py
+++ b/summarize-eaf.py
@@ -117,6 +117,9 @@ def get_events(segments, label_func=lambda x: x.tier):
     """
     events = []
     for segment in segments:
+        if segment.start_time > segment.end_time:
+            logging.warning('Found segment with start time (%s) > end time (%s)',
+                            segment.start_time, segment.end_time)
         # Start of segment
         events.append(Event(timestamp  = segment.start_time,
                             label      = label_func(segment),

--- a/summarize-eaf.py
+++ b/summarize-eaf.py
@@ -177,6 +177,9 @@ def process_events(events, masking_tiers = [], limiting_tier = None):
         # Either a new label started, or an existing one ended. Either
         # way, we need to update the list of current labels.
         if event.change > 0:
+            if event.label in section_tiers:
+                logging.warning('Found overlapping segments in tier %s at time %s',
+                                event.label, event.timestamp)
             section_tiers.add(event.label)
         else:
             if event.label in section_tiers:

--- a/summarize-eaf.py
+++ b/summarize-eaf.py
@@ -135,7 +135,6 @@ def process_events(events, masking_tiers = [], limiting_tier = None):
 
     # Initialize return values
     union_sum      = 0
-    sections       = []
     section_sums   = defaultdict(int)
 
     # Temporary loop variables
@@ -171,8 +170,6 @@ def process_events(events, masking_tiers = [], limiting_tier = None):
             section_duration = event.timestamp - section_start
             section_sums[section_label] += section_duration
             union_sum += section_duration
-            if section_duration > 0:
-                sections.append((section_label, section_duration))
 
         # Either a new label started, or an existing one ended. Either
         # way, we need to update the list of current labels.


### PR DESCRIPTION
This lets the user invoke the script to use the `code` tier to limit the counts to segments (or partial segments) where that tier is active, effectively truncating any annotated segments that cross the boundaries of the `code` tier. Invocation is like this:
```console
summarize-eaf.py -l code -i EE1 -- *.eaf
```