### PR TITLE
Guarantee that all tiers have OutputRecord objects

### DIFF
--- a/summarize-eaf.py
+++ b/summarize-eaf.py
@@ -389,6 +389,9 @@ for eaf_file in args.eaf_files:
     # Iterate through the tier combinations found above, and add the
     # total time that combination was the only one active
     for label in labels:
+        for top_tier in label.split('+'):
+            if top_tier not in output_records:
+                output_records[top_tier] = OutputRecord(file_id, top_tier)
         output_records[label] = OutputRecord(file_id, label)
         output_records[label].data['exclusive'] += section_sums[label]
         output_records['totals'].data['exclusive'] += section_sums[label]


### PR DESCRIPTION
If a tier (e.g. `TIER1`) consisted solely of segments fully overlapping segments from other tiers, it would result in no output record being created for that tier on its own (only `TIER1+TIER2`) in the `output_records` dictionary. When populating the output record for that tier from the section sums, it would then try to add an amount to a non-existent entry in the dictionary.

This change guarantees that if a tier appears in an overlap label, it will get its own separate entry in the `output_records` array, even if all of its segments are full-overlapping.