### PR TITLE
Add option to restricting limiting tier by regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ the others, and report totals from the other tiers as if the ignored tiers were
 not present. Most likely, this would be used to filter out electronic devices
 (i.e. the `EE1` tier).
 
+### Limiting the counted segments to the "code" tier
+
+The segments (or partial segments) included in the output can be limited to ones
+that overlap with the `code` tier (or any other specified tier) using the
+`--limiting-tier` option. If this option is used, only the portion of the EAF
+file that is marked with the specified tier (usually `code`) will be included in
+the output summary.
+
+With the `--limiting-tier-pattern` option, it's possible to further restrict the
+included sections to ones that are annotated with text that matches a specified
+regular expression. Only matching segments of the limiting tier will be
+summarized in the output, unless the option `--negate-limiting-tier-pattern` is
+also used, in which case the segments that match will be filtered out, and the
+non-matching segments of the limiting tier will be summarized instead.
+
 ### Using a tier as a mask
 
 The `--masking-tiers` option turns the specified tier into an "input mask" for

--- a/summarize-eaf.py
+++ b/summarize-eaf.py
@@ -178,7 +178,7 @@ def process_events(events, masking_tiers = [], limiting_tier = None):
         # way, we need to update the list of current labels.
         if event.change > 0:
             if event.label in section_tiers:
-                logging.warning('Found overlapping segments in tier %s at time %s',
+                logging.warning('Found overlapping segments in tier "%s" at time %s',
                                 event.label, event.timestamp)
             section_tiers.append(event.label)
         else:


### PR DESCRIPTION
This change adds two options to further restrict the output by requiring segments of the limiting tier to either match or not match a given regular expression. For example:
```console
$ summarize-eaf.py --limiting-tier code --limiting-tier-pattern 'random' --negate-limiting-tier-pattern *.eaf
```
That will only count segments (or the parts thereof) that overlap with segments of the `code` tier which do _not_ contain the string `random`.